### PR TITLE
Staging per container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_install:
 script:
 - pip install -r requirements-test.txt
 - pytest app/client_dfple_tests.py
+- pytest app/client_certbot_tests.py

--- a/app/app.py
+++ b/app/app.py
@@ -72,7 +72,7 @@ def reconfigure(version):
         if all([label in args.keys() for label in required_labels]):
             logger.info('letsencrypt support enabled.')
 
-            testing = False
+            testing = None
             if 'letsencrypt.testing' in args:
                 testing = args['letsencrypt.testing']
                 if isinstance(testing, basestring):

--- a/app/app.py
+++ b/app/app.py
@@ -72,7 +72,13 @@ def reconfigure(version):
         if all([label in args.keys() for label in required_labels]):
             logger.info('letsencrypt support enabled.')
 
-            client.process(args['letsencrypt.host'].split(','), args['letsencrypt.email'])
+            testing = False
+            if 'letsencrypt.testing' in args:
+                testing = args['letsencrypt.testing']
+                if isinstance(testing, basestring):
+                    testing = True if testing.lower() == 'true' else False
+
+            client.process(args['letsencrypt.host'].split(','), args['letsencrypt.email'], testing=testing)
 
     # proxy requests to docker-flow-proxy
     # sometimes we can get an error back from DFP, this can happen when DFP is not fully loaded.

--- a/app/client_certbot.py
+++ b/app/client_certbot.py
@@ -34,7 +34,7 @@ class CertbotClient():
 
         return output, error, process.returncode
 
-    def update_cert(self, domains, email, testing=False):
+    def update_cert(self, domains, email, testing=None):
         """
         Update certificates
         """
@@ -49,10 +49,8 @@ class CertbotClient():
         if testing:
             if -1 == self.options.find('--staging'):
                 self.options += ' --staging'
-        else:
-            """
-            TODO fix - this removes "staging", when set via CERT_OPTIONS !!!
-            """
+        elif False == testing:
+            # is true, and not None
             self.options = self.options.replace('--staging', '')
 
         logger.info('options after: {}'.format(self.options))

--- a/app/client_certbot.py
+++ b/app/client_certbot.py
@@ -45,15 +45,15 @@ class CertbotClient():
         if self.challenge == 'dns':
             c = "--manual --manual-public-ip-logging-ok --preferred-challenges dns --manual-auth-hook {} --manual-cleanup-hook {}".format(self.manual_auth_hook, self.manual_cleanup_hook)
 
-        logger.info('options before: {}'.format(self.options))
+        # is testing, add staging flag
         if testing:
             if -1 == self.options.find('--staging'):
                 self.options += ' --staging'
         elif False == testing:
-            # is true, and not None
+            # is not testing, remove staging flag
             self.options = self.options.replace('--staging', '')
+        # else don't do anything, because label was not set - use glboal settings
 
-        logger.info('options after: {}'.format(self.options))
 
         output, error, code = self.run("""certbot certonly \
                     --agree-tos \

--- a/app/client_certbot.py
+++ b/app/client_certbot.py
@@ -42,7 +42,7 @@ class CertbotClient():
         if testing and '--staging' not in opts:
             opts.append('--staging')
         # if not testing, remove staging flag
-        elif not testing and '--staging' in opts:
+        elif testing is False and '--staging' in opts:
             opts.remove('--staging')
 
         return ' '.join(opts)

--- a/app/client_certbot.py
+++ b/app/client_certbot.py
@@ -34,9 +34,9 @@ class CertbotClient():
 
         return output, error, process.returncode
 
-    def update_cert(self, domains, email):
+    def update_cert(self, domains, email, testing=False):
         """
-        Update certifacts
+        Update certificates
         """
 
         c = ''
@@ -44,6 +44,18 @@ class CertbotClient():
             c = "--webroot --webroot-path {}".format(self.webroot_path)
         if self.challenge == 'dns':
             c = "--manual --manual-public-ip-logging-ok --preferred-challenges dns --manual-auth-hook {} --manual-cleanup-hook {}".format(self.manual_auth_hook, self.manual_cleanup_hook)
+
+        logger.info('options before: {}'.format(self.options))
+        if testing:
+            if -1 == self.options.find('--staging'):
+                self.options += ' --staging'
+        else:
+            """
+            TODO fix - this removes "staging", when set via CERT_OPTIONS !!!
+            """
+            self.options = self.options.replace('--staging', '')
+
+        logger.info('options after: {}'.format(self.options))
 
         output, error, code = self.run("""certbot certonly \
                     --agree-tos \

--- a/app/client_certbot.py
+++ b/app/client_certbot.py
@@ -52,7 +52,7 @@ class CertbotClient():
         elif False == testing:
             # is not testing, remove staging flag
             self.options = self.options.replace('--staging', '')
-        # else don't do anything, because label was not set - use glboal settings
+        # else don't do anything, because label was not set - use global settings
 
 
         output, error, code = self.run("""certbot certonly \

--- a/app/client_certbot_tests.py
+++ b/app/client_certbot_tests.py
@@ -1,0 +1,20 @@
+import docker
+import os
+import shutil
+from mock import patch
+from unittest import TestCase
+
+from client_certbot import CertbotClient
+
+
+class CertbotClientTestCase(TestCase):
+
+	def test_staging_per_container(self):
+		certbot_client = CertbotClient(challenge='http', webroot_path='/tmp')
+		assert '--staging' in certbot_client.get_options(testing=True)
+		certbot_client = CertbotClient(challenge='http', webroot_path='/tmp', options="--staging")
+		assert '--staging' in certbot_client.get_options(testing=True)
+		certbot_client = CertbotClient(challenge='http', webroot_path='/tmp')
+		assert '--staging' not in certbot_client.get_options(testing=False)
+		certbot_client = CertbotClient(challenge='http', webroot_path='/tmp', options="--staging")
+		assert '--staging' not in certbot_client.get_options(testing=False)

--- a/app/client_certbot_tests.py
+++ b/app/client_certbot_tests.py
@@ -18,3 +18,7 @@ class CertbotClientTestCase(TestCase):
 		assert '--staging' not in certbot_client.get_options(testing=False)
 		certbot_client = CertbotClient(challenge='http', webroot_path='/tmp', options="--staging")
 		assert '--staging' not in certbot_client.get_options(testing=False)
+		certbot_client = CertbotClient(challenge='http', webroot_path='/tmp', options="--staging")
+		assert '--staging' in certbot_client.get_options(testing=None)
+		certbot_client = CertbotClient(challenge='http', webroot_path='/tmp')
+		assert '--staging' not in certbot_client.get_options(testing=None)

--- a/app/client_dfple.py
+++ b/app/client_dfple.py
@@ -26,7 +26,7 @@ class DFPLEClient():
         self.certbot = CertbotClient(
             challenge=kwargs.get('certbot_challenge'),
             webroot_path=kwargs.get('certbot_webroot_path'),
-            options=kwargs.get('certbot_options'),
+            options=kwargs.get('certbot_options', ''),
             manual_auth_hook=kwargs.get('certbot_manual_auth_hook'),
             manual_cleanup_hook=kwargs.get('certbot_manual_cleanup_hook')
             )

--- a/app/client_dfple.py
+++ b/app/client_dfple.py
@@ -106,7 +106,7 @@ class DFPLEClient():
         secret = self.docker_client.secrets.get(secret.id)
         return secret
 
-    def generate_certificates(self, domains, email, testing=False):
+    def generate_certificates(self, domains, email, testing=None):
         """
             Generate or renew certificates for given domains
 
@@ -165,7 +165,7 @@ class DFPLEClient():
 
         return certs, created
 
-    def process(self, domains, email, version='1', testing=False):
+    def process(self, domains, email, version='1', testing=None):
         logger.info('Letsencrypt support enabled, processing request: domains={} email={} testing={}'.format(','.join(domains), email, testing))
 
         certs, created = self.generate_certificates(domains, email, testing)

--- a/app/client_dfple.py
+++ b/app/client_dfple.py
@@ -106,10 +106,11 @@ class DFPLEClient():
         secret = self.docker_client.secrets.get(secret.id)
         return secret
 
-    def generate_certificates(self, domains, email):
+    def generate_certificates(self, domains, email, testing=False):
         """
             Generate or renew certificates for given domains
 
+            :param testing: Issue testing / staging certificate
             :param domains: Domain names to generate certificates. Comma separated.
             :param email: Email used during letsencrypt process
             :type a: string
@@ -121,8 +122,8 @@ class DFPLEClient():
         for domain in domains:
             certs[domain] = []
 
-        logger.debug('Generating certificates domains:{} email:{}'.format(domains, email))
-        error, created = self.certbot.update_cert(domains, email)
+        logger.debug('Generating certificates domains:{} email:{} testing:{}'.format(domains, email, testing))
+        error, created = self.certbot.update_cert(domains, email, testing)
 
         if error and not created:
             logger.error('Error while generating certs for {}'.format(domains))
@@ -164,10 +165,10 @@ class DFPLEClient():
 
         return certs, created
 
-    def process(self, domains, email, version='1'):
-        logger.info('Letsencrypt support enabled, processing request: domains={} email={}'.format(','.join(domains), email))
+    def process(self, domains, email, version='1', testing=False):
+        logger.info('Letsencrypt support enabled, processing request: domains={} email={} testing={}'.format(','.join(domains), email, testing))
 
-        certs, created = self.generate_certificates(domains, email)
+        certs, created = self.generate_certificates(domains, email, testing)
 
         secrets_changed = False
         if self.docker_client != None:

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,4 +1,13 @@
-# configuration
+# Configuration
+
+## Labels
+
+| Name                           |      Description                                                                       | Default   |
+|--------------------------------|:--------------------------------------------------------------------------------------:|----------:|
+| com.df.letsencrypt.host        | Comma separated list of domains letsencrypt will generate/update certs for.            |           |
+| com.df.letsencrypt.email       | Email used by letsencrypt when registering cert.                                       |           |
+| com.df.letsencrypt.testing     | Enable/disable staging per service. Please see [#13](https://github.com/n1b0r/docker-flow-proxy-letsencrypt/pull/13) |           |
+
 
 ## Environment variables
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,8 @@ repo_url: https://github.com/n1b0r/docker-flow-proxy-letsencrypt
 site_author: Robin Lucbernet
 copyright: Copyright © 2017 Robin Lucbernet
 strict: true
-theme: 'material'
+theme: 
+  name: 'material'
 extra:
   palette:
     primary: 'blue'


### PR DESCRIPTION
Adding support for choosing staging / live certs per container.

Use service label `com.df.letsencrypt.testing`.
This label is not required.

Expected behaviour:
if `CERTBOT_OPTIONS=--staging`
- if `com.df.letsencrypt.testing=true` -> use **staging**
- if `com.df.letsencrypt.testing=false` -> use **live**
- if `com.df.letsencrypt.testing` not set -> use **staging** (because of CERTBOT_OPTIONS)

if `CERTBOT_OPTIONS` is empty:
- if `com.df.letsencrypt.testing=true` -> use **staging**
- if `com.df.letsencrypt.testing=false` -> use **live**
- if `com.df.letsencrypt.testing` not set -> use **live** (because of CERTBOT_OPTIONS is empty, and default is live)

I testing all of these combinations, and worked fine.
