### PR TITLE
Simplify host setup

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -64,7 +64,7 @@ def reconfigure(version):
 
         logger.info('request for service: {}'.format(args.get('serviceName')))
 
-        # Check if the newly registered service is usign letsencrypt companion.
+        # Check if the newly registered service is using letsencrypt companion.
         # Labels required:
         #   * com.df.letsencrypt.host
         #   * com.df.letsencrypt.email


### PR DESCRIPTION
Adding the ability to determine LE hosts from `serviceDomain` label.
In code I added in comment various usages, which I considered.

As before, I didn't include tests, as I'm pretty newbie in Python and don't even know how to do that.
But I tested on my server :)