### PR TITLE
Ensure crond.log exists to prevent error on start.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --update curl
 RUN mkdir -p /opt/www
 RUN mkdir -p /etc/letsencrypt
 RUN mkdir -p /var/lib/letsencrypt
+RUN touch /var/log/crond.log
 
 COPY ./requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt


### PR DESCRIPTION
As I described in [an issue](https://github.com/n1b0r/docker-flow-proxy-letsencrypt/issues/21) a few weeks ago, I was seeing an error in my logs every time I started the `letsencrypt` container for my Docker Flow Proxy stack. I resolved it by creating `/var/log/crond.log` as an empty file early in the Dockerfile to ensure that it always exists at start-up.

I've had this running on my development server (in staging mode) for a few weeks now without issue.