### PR TITLE
New build required to support ACMEv2

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -93,7 +93,7 @@ def reconfigure(version):
                 '&'.join(['{}={}'.format(k, v) for k, v in request.args.items()]))))
             if response.status_code == 200:
                 break
-        except Exception, e:
+        except Exception as e:
             logger.error('Error while trying to forward request: {}'.format(e))
         logger.debug('waiting for retry')
         time.sleep(os.environ.get('RETRY_INTERVAL', 5))

--- a/tests.py
+++ b/tests.py
@@ -84,7 +84,7 @@ class DFPLETestCase(TestCase):
     def get_conf(self):
         try:
             return requests.get('http://{}:8080/v1/docker-flow-proxy/config'.format(self.base_domain), timeout=3).text
-        except Exception, e:
+        except Exception as e:
             print('Error while getting config on {}: {}'.format(self.base_domain, e))
             return False
 


### PR DESCRIPTION
I have build the image with latest certbot version as ACMEv1 is deprecated.

Errror i got from current 0.7 version:
_Account creation on ACMEv1 is disabled. Please upgrade your ACME client to a version that supports ACMEv2 / RFC 8555. See https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430 for details._

also had some small python issues which i fixed.

Please update with a new build so that others will not face issues when certificate needs renewal.